### PR TITLE
Catch runtime exception

### DIFF
--- a/src/Jenkins.php
+++ b/src/Jenkins.php
@@ -132,7 +132,7 @@ class Jenkins
         } else {
             try {
                 $this->getQueue();
-            } catch (RuntimeException $e) {
+            } catch (\RuntimeException $e) {
                 //en cours de lancement de jenkins, on devrait passer par là
                 return false;
             }


### PR DESCRIPTION
In case of 403 return code call using isAvailable will fail.